### PR TITLE
v0.14.26 - Bugfix/#894

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Changes
 -------
 Unreleased
 ==========
+2020-11-10 v0.14.26
+disable http cache, redirect to https
+
 2020-11-07 v0.14.25
 insert French email template for reset password
 

--- a/girderformindlogger/api/rest.py
+++ b/girderformindlogger/api/rest.py
@@ -540,6 +540,15 @@ def _createResponse(val):
     # Default behavior will just be normal JSON output. Keep this
     # outside of the loop body in case no Accept header is passed.
     setResponseHeader('Content-Type', 'application/json')
+
+    # disable api responses to be automatically cached on frontend
+    setResponseHeader('Cache-Control', 'private, no-cache, no-store, max-age=0')
+    setResponseHeader('Pragma', 'no-cache')
+    setResponseHeader('Expires', '0')
+
+    # use https
+    setResponseHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+
     return json.dumps(val, sort_keys=True, allow_nan=False,
                       cls=JsonEncoder).encode('utf8')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@girder/lint",
-    "version": "0.14.25",
+    "version": "0.14.26",
     "description": "Extensible data management platform",
     "homepage": "https://girderformindlogger.readthedocs.org",
     "bugs": {


### PR DESCRIPTION
- issue [894](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-backend/894)

- disable caching, redirect to https
