### PR TITLE
allow folder parent type for applets

### DIFF
--- a/girderformindlogger/models/applet.py
+++ b/girderformindlogger/models/applet.py
@@ -1619,7 +1619,7 @@ class Applet(FolderModel):
                 parent = pathFromRoot[-1]['object']
                 if (
                     parent['name'] == "Applets" and
-                    doc['baseParentType'] in {'collection', 'user'}
+                    doc['baseParentType'] in {'collection', 'user', 'folder'}
                 ):
                     """
                     Check if parent is "Applets" collection or user

--- a/girderformindlogger/models/item.py
+++ b/girderformindlogger/models/item.py
@@ -42,6 +42,13 @@ class Item(acl_mixin.AccessControlMixin, Model):
                     ('name', 1),
                     ('meta.screen.@type', 1),
                     ('meta.screen.url', 1)
+                ], {}),
+                ([
+                    ('baseParentId', 1),
+                    ('meta.applet.@id', 1),
+                    ('meta.subject.@id', 1),
+                    ('baseParentType', 1),
+                    ('isCumulative', 1)
                 ], {})
             )
         )


### PR DESCRIPTION
# Resolves [640](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/640)
# Inserted index in item collection to optimize searching responses.