### PR TITLE
fix published status for duplicated applet

### DIFF
--- a/girderformindlogger/models/applet.py
+++ b/girderformindlogger/models/applet.py
@@ -387,7 +387,8 @@ class Applet(FolderModel):
                     ObjectId(protocol['activities'][activity]['_id'].split('/')[-1]) for activity in protocol['activities']
                 ],
                 'name': prefLabel
-            }
+            },
+            'published': False
         }
         metadata['applet']['displayName'] = appletName
 


### PR DESCRIPTION
# Resolves [22](https://app.zenhub.com/workspaces/mindlogger-webapp-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-applet-library/22)
