### PR TITLE
Fix share with library feature for applets in folder

### DIFF
--- a/girderformindlogger/api/v1/folder.py
+++ b/girderformindlogger/api/v1/folder.py
@@ -185,6 +185,8 @@ class Folder(Resource):
 
                 formatted['updated'] = applet['updated']
                 formatted['accountId'] = applet['accountId']
+                formatted['hasUrl'] = (applet['meta'].get('protocol', {}).get('url', None) != None)
+                formatted['published'] = applet['meta'].get('published', False)
 
                 if _applet.get('_pin_order'):
                     formatted['pinOrder']=_applet['_pin_order']


### PR DESCRIPTION
# Resolves [#1059](https://app.zenhub.com/workspaces/mindlogger-webapp-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/1059)