### PR TITLE
add Dockerfile and docker-compose for running locally

### DIFF
--- a/Dockerfile.local.dev
+++ b/Dockerfile.local.dev
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y python3.6 \
+    git \
+    nodejs \
+    npm \
+    python3-pip
+
+RUN pip3 install -U pip setuptools
+
+RUN mkdir /mindlogger-backend
+WORKDIR /mindlogger-backend
+
+COPY . .
+RUN pip3 install -r requirements.txt
+RUN pip3 install -e .
+
+# See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on
+# why this is necessary.
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN girderformindlogger build
+CMD [ "girderformindlogger","serve" ]

--- a/Dockerfile.local.dev
+++ b/Dockerfile.local.dev
@@ -11,9 +11,11 @@ RUN pip3 install -U pip setuptools
 
 RUN mkdir /mindlogger-backend
 WORKDIR /mindlogger-backend
+#copy and install requirements early to allow faster rebuilds as these layers will be cached 
+COPY ./requirements.txt ./requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . .
-RUN pip3 install -r requirements.txt
 RUN pip3 install -e .
 
 # See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on
@@ -21,5 +23,5 @@ RUN pip3 install -e .
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-RUN girderformindlogger build
+RUN girderformindlogger build --dev
 CMD [ "girderformindlogger","serve" ]

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,40 @@ Windows
 
       deactivate
 
+Docker
+######
+
+The database and api can be run using docker-compose for local development purposes.
+
+1. make sure docker is running. For example:
+
+   .. code-block:: shell
+
+      docker -v
+         Docker version 20.10.7, build f0df350
+
+
+2. run the db and api.
+
+   .. code-block:: shell
+
+      docker-compose -f docker-compose.local.yml up
+
+
+The first time this command is run will take a few minutes as the images are downloaded and built.
+
+3. make some changes to your local code and restart the girderformindlogger container to see the changes.
+
+   .. code-block:: shell
+
+      docker-compose -f docker-compose.local.yml restart girderformindlogger
+
+or  
+
+   .. code-block:: shell
+
+      docker restart mindlogger-backend_girderformindlogger_1
+
 Deployment
 ----------
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  mongo:
+    image: mongo:4-bionic
+    ports:
+      - 27017:27017
+      - 27018:27018
+      - 27019:27019
+    volumes:
+      - "mongovolume:/data/db"
+    environment:
+      MONGO_INITDB_DATABASE: girderformindlogger
+      MONGO_INITDB_ROOT_USERNAME: mongouser
+      MONGO_INITDB_ROOT_PASSWORD: mongopass
+    command: ["--auth"]      
+
+  girderformindlogger:
+    build:
+      context: .
+      dockerfile: Dockerfile.local.dev
+    volumes: 
+      - "./girderformindlogger:/girderformindlogger"
+    ports:
+      - "8081:8081"
+    environment:
+      GIRDER_PORT: 8081
+      GIRDER_MONGO_URI: http://localhost:8081
+      GIRDER_TEST_DB: girder-test
+      MONGODB_URI: mongodb://mongouser:mongopass@mongo:27017
+      DB_NAME: girderformindlogger
+      ACCESS_KEY_ID: 1
+      SECRET_ACCESS_KEY: 1
+      HTTP_HOST: localhost
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    command: ["girderformindlogger", "serve","--host","0.0.0.0","--database","mongodb://mongouser:mongopass@mongo:27017"]
+
+volumes:
+  mongovolume:
+      driver: local

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  mongo:
+  db:
     image: mongo:4-bionic
     ports:
       - 27017:27017
@@ -9,13 +9,14 @@ services:
       - 27019:27019
     volumes:
       - "mongovolume:/data/db"
+      - ./mongo-local-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh
     environment:
-      MONGO_INITDB_DATABASE: girderformindlogger
       MONGO_INITDB_ROOT_USERNAME: mongouser
       MONGO_INITDB_ROOT_PASSWORD: mongopass
-    command: ["--auth"]      
+      MONGO_INITDB_DATABASE: girderformindlogger
+    command: ["--auth"]
 
-  girderformindlogger:
+  api:
     build:
       context: .
       dockerfile: Dockerfile.local.dev
@@ -24,17 +25,17 @@ services:
     ports:
       - "8081:8081"
     environment:
-      GIRDER_PORT: 8081
-      GIRDER_MONGO_URI: http://localhost:8081
-      GIRDER_TEST_DB: girder-test
-      MONGODB_URI: mongodb://mongouser:mongopass@mongo:27017
-      DB_NAME: girderformindlogger
-      ACCESS_KEY_ID: 1
-      SECRET_ACCESS_KEY: 1
       HTTP_HOST: localhost
+      GIRDER_PORT: 8081
+      SECRET_ACCESS_KEY: 1
+      ACCESS_KEY_ID: 1co
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
-    command: ["girderformindlogger", "serve","--host","0.0.0.0","--database","mongodb://mongouser:mongopass@mongo:27017"]
+    command: >
+      sh -c "echo 'wait for db to start' &&
+             sleep 10 &&
+             girderformindlogger serve --host 0.0.0.0 --database mongodb://mongouser:mongopass@db:27017/girderformindlogger
+      "
 
 volumes:
   mongovolume:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,7 +21,7 @@ services:
       context: .
       dockerfile: Dockerfile.local.dev
     volumes: 
-      - "./girderformindlogger:/girderformindlogger"
+      - "./girderformindlogger:/mindlogger-backend/girderformindlogger"
     ports:
       - "8081:8081"
     environment:
@@ -32,7 +32,7 @@ services:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     command: >
-      sh -c "echo 'wait for db to start' &&
+      sh -c "echo 'wait 10s for db to start' &&
              sleep 10 &&
              girderformindlogger serve --host 0.0.0.0 --database mongodb://mongouser:mongopass@db:27017/girderformindlogger
       "

--- a/mongo-local-init.sh
+++ b/mongo-local-init.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e;
+# the mongo image only creates a root user in the admin database and not in the initdb_database
+# so this script will grant a root role in the initdb_database aswell
+
+# a default non-root role
+# MONGO_NON_ROOT_ROLE="${MONGO_NON_ROOT_ROLE:-readWrite}"
+
+if [ -n "${MONGO_INITDB_ROOT_USERNAME:-}" ] && [ -n "${MONGO_INITDB_ROOT_PASSWORD:-}" ]; then
+	"${mongo[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+        db.createUser({
+            user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+            pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+            roles: [ 
+                { role: $(_js_escape "root"), db: $(_js_escape "admin") }, 
+                { role: "dbOwner", db: $(_js_escape "$MONGO_INITDB_DATABASE") } 
+                ]
+            })
+	EOJS
+    		# db.createUser({
+			# user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+			# pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+			# roles: [ { role: "dbOwner", db: $(_js_escape "$MONGO_INITDB_DATABASE") }, ]
+			# })
+        #             db.grantRolesToUser(
+        #     $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+        #     [
+        #     { role: "root", db: $(_js_escape "$MONGO_INITDB_DATABASE") }
+        #     ]
+        # )
+
+        #     db.createUser({
+		# 	user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+		# 	pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+		# 	roles: [ { role: $(_js_escape "root"), db: $(_js_escape "admin") }, ]
+		# 	})
+# else
+# 	# print warning or kill temporary mongo and exit non-zero
+fi

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-with open('README.rst') as f:
+with open('README.rst', 'r', encoding='utf8') as f:
     readme = f.read()
 
 installReqs = [


### PR DESCRIPTION
responds to issue #1083 

includes:
* Dockerfile based on Ubuntu:18.04
* docker-compose file to run mongodb and girderformindlogger  

The girderformindlogger container mounts the local files to implement changes on the host machine.
As the intention is for easy local use, env variables/passwords are included directly in the docker-compose file.

The image is relatively large (~1.25GB), but is much faster to build and easier to work with than smaller images (e.g. alpine).

to run 
```
docker-compose -f docker-compose.local.yml up
```