### PR TITLE
Fix: ML-160

### DIFF
--- a/girderformindlogger/models/applet.py
+++ b/girderformindlogger/models/applet.py
@@ -979,7 +979,7 @@ class Applet(FolderModel):
 
                 EventsModel().update({ 'data.activity_id': activityId }, {
                     '$set': {
-                        'data.title': self.preferredName(activity['meta'].get('activity', {})),
+                        'data.title': activity["name"],
                     },
                 })
 
@@ -1006,7 +1006,7 @@ class Applet(FolderModel):
 
                 EventsModel().update({ 'data.activity_flow_id': activityFlowId }, {
                     '$set': {
-                        'data.title': self.preferredName(activityFlow)
+                        'data.title': activityFlow["@id"]
                     }
                 })
 


### PR DESCRIPTION
Calendar: Activity names on events are replaced with "..._schema" names after hiding the activity in the builder https://mindlogger.atlassian.net/jira/software/projects/ML/boards/1/backlog?issueParent=0%2C10069%2C10068%2C10067%2C10066%2C10113&selectedIssue=ML-160